### PR TITLE
feat: createContent method 채우기

### DIFF
--- a/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
@@ -37,7 +37,7 @@ public class ContentController {
     @PostMapping
     @Operation(summary = "content 작성", description = "content를 작성한다.")
     public CreateContentResponse createContent(@RequestBody @Valid CreateContentRequest createContentRequest) {
-        return new CreateContentResponse();
+        return new CreateContentResponse(contentService.createContent(createContentRequest));
     }
 
     @GetMapping("/{contentId}")

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ContentResponseDto.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ContentResponseDto.java
@@ -1,4 +1,11 @@
 package pudding.toy.ourJourney.dto.content;
 
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+
+
 public class ContentResponseDto {
+
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/CreateContentRequest.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/CreateContentRequest.java
@@ -1,4 +1,21 @@
 package pudding.toy.ourJourney.dto.content;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.*;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class CreateContentRequest {
+    @NotNull @Size(min = 1, max = 10, message = "제목은 1 ~ 10자 이여야 합니다!")
+    String title;
+    @NotNull
+    Long categoryId;
+    @NotNull
+    List<Long> attendeeIds;
+    List<Long> tagIds;
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/CreateContentResponse.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/CreateContentResponse.java
@@ -5,4 +5,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CreateContentResponse {
     private Long id;
+    public CreateContentResponse(Long id){
+        this.id = id;
+    }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Contents.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Contents.java
@@ -2,6 +2,7 @@ package pudding.toy.ourJourney.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -30,5 +31,11 @@ public class Contents extends BaseTimeEntity {
     List<ContentLike> contentLikes;
     @OneToMany(mappedBy = "contents")
     List<ContentsThread> contentsThreads;
+    @Builder
+    public Contents(String title,Category category,ContentTag contentTag){
+        this.title = title;
+        this.category = category;
+        this.contentTags.add(contentTag);
+    }
 
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
@@ -1,10 +1,16 @@
 package pudding.toy.ourJourney.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pudding.toy.ourJourney.dto.content.*;
+import pudding.toy.ourJourney.entity.Category;
+import pudding.toy.ourJourney.entity.ContentTag;
+import pudding.toy.ourJourney.entity.Contents;
+import pudding.toy.ourJourney.repository.CategoryRepository;
+import pudding.toy.ourJourney.repository.ContentRepository;
 
 import java.util.List;
 
@@ -12,13 +18,24 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class ContentService {
+    private final ContentRepository contentRepository;
+    private final CategoryRepository categoryRepository;
     public PageImpl<ContentResponseDto> getAllContents(ContentRequestDto contentRequestDto) {
         List<ContentResponseDto> list = List.of(new ContentResponseDto());
         return new PageImpl<>(list);
     }
 
-    public CreateContentResponse createContent(CreateContentRequest createContentRequest) {
-        return new CreateContentResponse();
+    public Long createContent(CreateContentRequest createContentRequest) {
+        Category category = categoryRepository.findById(createContentRequest.getCategoryId()).orElseThrow(
+                ()-> new IllegalArgumentException("category 없음")
+        ); //todo: 논의
+        // ContentTag contentTag; -> 태그는 뭔가,, 데베에서 찾는게 아니라 그때그떄 생성되는느낌인데 어떻게 할까요?
+        Contents content = Contents.builder()
+                .title(createContentRequest.getTitle())
+                .category(category)
+                .build();
+        contentRepository.save(content);
+        return content.getId();
     }
 
     public DetailContentResponseDto getOneContent(Long contentId) {


### PR DESCRIPTION
## 📝 제목
createContent 에 대한 method 채우기
  
  
## ✨ 작업 내용
- Content를 create시, dto안의 필드를 채웠습니다. (API 문서대로 채웠습니다.)
- ContentService 에서 createContent를 구현했습니다.
  
  
## 💁‍♀️ 참고 사항
- 일단 적어본거라서 완전히 구현된 내용은 아닙니다!
  
## 🤔 논의 사항
- API 문서에서 TagId를 받는다고 했는데 tag같은 경우는 먼저 정의해두는게 아니라 그때 그때 생성된다고 생각해서, tag를 받으면 새로운 Tag 엔티티를 생성해야 할 것 같습니다..!

  
## 🔧 앞으로의 과제
<!-- 작업 후, 남아있는 사항이나 기술 부채 등 작업한 내용과 연관되거나 해야할 사항이 있다면 남겨주세요. -->
<!-- 해당 내용들은 추후 새로운 태스크 등으로 등록하면서 관리하도록 해요. -->

  
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 [이슈 제목 #이슈번호](이슈 링크)로 남겨주세요. -->

  
