### PR TITLE
:sparkles: content 동적쿼리 페이지네이션 적용

### DIFF
--- a/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
@@ -27,8 +27,7 @@ public class ContentController {
     @GetMapping()
     @Operation(summary = "content 보기", description = "content를 검색한다.")
     public GetContentResponse getAllContents(Pageable pageable, @RequestParam Optional<Long> categoryId, @RequestParam Optional<String> title, @RequestParam Optional<List<Long>> tagIds) {
-        List<ListContentDto> list = List.of(new ListContentDto());
-        return new GetContentResponse(new PageImpl<>(list, pageable, 1L));
+        return new GetContentResponse(contentService.getAllContents(pageable,categoryId,title,tagIds));
     }
 
     @PostMapping

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ContentProfileDto.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ContentProfileDto.java
@@ -1,0 +1,12 @@
+package pudding.toy.ourJourney.dto.content;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ContentProfileDto {
+    private Long profileId;
+    private String profileImgUrl;
+    private String name;
+}

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ListContentDto.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/ListContentDto.java
@@ -2,17 +2,28 @@ package pudding.toy.ourJourney.dto.content;
 
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
+import pudding.toy.ourJourney.entity.Contents;
 
 import java.time.LocalDateTime;
 
-@Data @FieldDefaults(level = AccessLevel.PRIVATE)
+@Data @FieldDefaults(level = AccessLevel.PRIVATE) @AllArgsConstructor
 public class ListContentDto {
     Long contentId;
     String title;
     String postImg;
+    ContentProfileDto contentProfileDto;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
+    public ListContentDto(Contents contents){
+        this.contentId = contents.getId();
+        this.title = contents.getTitle();
+        this.postImg = contents.getImgUrl();
+        this.contentProfileDto = new ContentProfileDto(contents.getProfile().getId(), contentProfileDto.getProfileImgUrl(), contentProfileDto.getName());
+        this.createdAt =  contents.getCreatedAt();
+        this.updatedAt = contents.getUpdateAt();
+    }
 
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/repository/ContentsQueryRepository.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/repository/ContentsQueryRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import pudding.toy.ourJourney.dto.content.ListContentDto;
 import pudding.toy.ourJourney.entity.Contents;
 
 import java.util.List;
@@ -18,7 +19,7 @@ import static pudding.toy.ourJourney.entity.QContents.contents;
 public class ContentsQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
-    public PageImpl<Contents> findAll(
+    public PageImpl<ListContentDto> findAll(
             Pageable pageable,
             Optional<Long> categoryId,
             Optional<String> title,
@@ -29,12 +30,15 @@ public class ContentsQueryRepository {
                 .limit(pageable.getPageSize())
                 .select(contents)
                 .fetch();
+        List<ListContentDto> listDto = list.stream()
+                .map(content -> new ListContentDto(content))
+                .toList();
 
         Long count = baseQuery(categoryId, title, tagIds)
                 .select(contents.count())
                 .fetchFirst();
 
-        return new PageImpl<>(list, pageable, count);
+        return new PageImpl<>(listDto, pageable, count);
     }
 
     private JPAQuery<?> baseQuery(

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/repository/ContentsQueryRepository.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/repository/ContentsQueryRepository.java
@@ -31,7 +31,7 @@ public class ContentsQueryRepository {
                 .select(contents)
                 .fetch();
         List<ListContentDto> listDto = list.stream()
-                .map(content -> new ListContentDto(content))
+                .map(ListContentDto::new)
                 .toList();
 
         Long count = baseQuery(categoryId, title, tagIds)

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
@@ -1,23 +1,20 @@
 package pudding.toy.ourJourney.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.data.DataRestTagsService;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 import pudding.toy.ourJourney.dto.content.*;
 import pudding.toy.ourJourney.entity.Category;
 import pudding.toy.ourJourney.entity.Contents;
 import pudding.toy.ourJourney.entity.Profile;
 import pudding.toy.ourJourney.mapper.EditContentsMapper;
-import pudding.toy.ourJourney.repository.AttendeeRepository;
 import pudding.toy.ourJourney.repository.CategoryRepository;
 import pudding.toy.ourJourney.repository.ContentRepository;
-
-import java.awt.print.Pageable;
+import pudding.toy.ourJourney.repository.ContentsQueryRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,14 +28,14 @@ public class ContentService {
     private final EditContentsMapper contentsMapper;
     private final AttendeeService attendeeService;
     private final TagService tagService;
+    private final ContentsQueryRepository contentsQueryRepository;
 
-    public PageImpl<ListContentDto> getAllContents( //todo:구현
+    public PageImpl<ListContentDto> getAllContents(
             Pageable pageable,
             Optional<Long> categoryId,
-            Optional<String> content,
+            Optional<String> title,
             Optional<List<Long>> tagIds) {
-        List<ListContentDto> list = List.of(new ListContentDto());
-        return new PageImpl<>(list);
+        return contentsQueryRepository.findAll(pageable,categoryId,title,tagIds);
     }
 
     public Long createContent(CreateContentRequest createContentRequest, Profile profile) {

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/mapper/ContentMapperTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/mapper/ContentMapperTest.java
@@ -24,7 +24,6 @@ public class ContentMapperTest {
     EditContentsMapper contentsMapper;
     Contents content;
     Category category;
-    ContentService contentService;
     ProfileInitializer profileInitializer;
     @BeforeEach
     void setUp(){


### PR DESCRIPTION
## 📝 제목
:sparkles: content 동적쿼리 페이지네이션 적용
  
  
## ✨ 작업 내용
- contentService에서 getAllContents 메서드 구현.
- content 리스트를 내려줄 때, 사용자 프로필 사진과 닉네임도 내려주는 것 같아 contentProflieDto를 생성했습니다!
- ContentsQueryRepository 에서 PageImpl<Content> 로 되어있는 부분을 ListContentDto로 고쳤습니다.

## 💁‍♀️ 참고 사항
[동적쿼리](https://velog.io/@wonizizi99/Spring-%EC%8B%A4%EC%A0%84-QueryDsl-Spring-Data-Jpa-2-%EB%8F%99%EC%A0%81-%EC%BF%BC%EB%A6%AC%EC%99%80-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94-%EC%A1%B0%ED%9A%8C)

  
## 🤔 논의 사항

  
## 🔧 앞으로의 과제
- 프로필과 좋아요 구현

  
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 [이슈 제목 #이슈번호](이슈 링크)로 남겨주세요. -->

  
