### PR TITLE
✨  feat: Profile 수정, 조회, 삭제 구현 + attendeeTest 문제 해결 + UpdateProfileMapper + Profile 자개소개 get 리턴값 변경

### DIFF
--- a/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ContentController.java
@@ -5,12 +5,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import pudding.toy.ourJourney.config.ProfileInitializer;
 import pudding.toy.ourJourney.dto.content.*;
-import pudding.toy.ourJourney.service.AuthService;
 import pudding.toy.ourJourney.service.ContentService;
 
 import java.util.List;
@@ -45,7 +43,7 @@ public class ContentController {
 
     @PatchMapping("/{contentId}")
     @Operation(summary = "content 수정", description = "content 한 개 수정한다.")
-    public void updateContent(@PathVariable("contentId") Long contentId, @RequestBody EditContentRequest editContent) {
+    public void updateContent(@PathVariable("contentId") Long contentId, @RequestBody UpdateContentRequest editContent) {
         contentService.updateContent(contentId,editContent);
     }
 

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ProfileController.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ProfileController.java
@@ -29,13 +29,14 @@ public class ProfileController {
     @Operation(summary = "프로필 조회")
     @GetMapping("/{id}")
     public GetDetailProfileResponse getProfile(@PathVariable Long id) {
-        return new GetDetailProfileResponse(1L, Optional.of("nickname"), null, null);
+        return profileService.getDetailProfile(id);
     }
 
     // TODO: login_required && is_owner
     @Operation(summary = "프로필 수정")
     @PatchMapping("/{id}")
     public void updateProfile(@PathVariable Long id, @RequestBody UpdateProfileRequest body) {
+        profileService.updateMyProfile(id,body);
     }
 
     @Operation(summary = "내가 작성한 글 가져오기")

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ProfileController.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/controller/ProfileController.java
@@ -7,12 +7,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
+import pudding.toy.ourJourney.dto.auth.ProfileAuthRequest;
 import pudding.toy.ourJourney.dto.profile.*;
 import pudding.toy.ourJourney.service.ProfileService;
 
 import java.util.List;
-import java.util.Optional;
 
 @Tag(name = "Profile API")
 @RestController
@@ -22,7 +21,7 @@ public class ProfileController {
     private final ProfileService profileService;
     @Operation(summary = "프로필 생성", description = "장고 서버에서 회원가입이 완료되면 호출합니다.")
     @PostMapping("")
-    public NewProfileResponse createProfile(@RequestBody ProfileAuthResponseDto body) {
+    public NewProfileResponse createProfile(@RequestBody ProfileAuthRequest body) {
         return profileService.createProfile(body);
     }
 

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/auth/ProfileAuthRequest.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/auth/ProfileAuthRequest.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import pudding.toy.ourJourney.entity.Profile;
 
 @Data @NoArgsConstructor @AllArgsConstructor
-public class ProfileAuthResponseDto { //django 가 보내주는 요청에 대한 응답이 유저 pk
+public class ProfileAuthRequest { //django 가 보내주는 요청에 대한 응답이 유저 pk
     @JsonProperty("user_id")
     Long id; //user pk
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/UpdateContentRequest.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/content/UpdateContentRequest.java
@@ -5,15 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.openapitools.jackson.nullable.JsonNullable;
-import pudding.toy.ourJourney.entity.ContentTag;
-import pudding.toy.ourJourney.entity.Contents;
 
 import java.util.List;
 
 @Data @FieldDefaults(level = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @RequiredArgsConstructor @Builder
-public class EditContentRequest {
+public class UpdateContentRequest {
     String title;
     @Schema(implementation = String.class)
     JsonNullable<String> imgUrl;

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/GetDetailProfileResponse.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/GetDetailProfileResponse.java
@@ -11,13 +11,13 @@ public class GetDetailProfileResponse {
     @NotNull
     private Long profileId;
     @Size(max = 32)
-    private Optional<String> nickname;
+    private String nickname;
     @Size(max = 255)
     private Optional<String> imageUrl;
     @Size(max = 255)
     private Optional<String> selfIntroduction;
 
-    public GetDetailProfileResponse(Long profileId, Optional<String> nickname, Optional<String> imageUrl, Optional<String> selfIntroduction) {
+    public GetDetailProfileResponse(Long profileId, String nickname, Optional<String> imageUrl, Optional<String> selfIntroduction) {
         this.profileId = profileId;
         this.nickname = nickname;
         this.imageUrl = imageUrl;

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/ProfileEditRequestDto.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/ProfileEditRequestDto.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
+import pudding.toy.ourJourney.dto.auth.ProfileAuthRequest;
 import pudding.toy.ourJourney.entity.Profile;
 
 @Data @NoArgsConstructor @AllArgsConstructor
 public class ProfileEditRequestDto { //todo: 장고와 변수 이름을 맞출 필요가 있습니다.
     @JsonProperty("user_id")
     int id; //user pk
-    public static Profile toEntity(ProfileAuthResponseDto profileAuthResponseDto){
-        return Profile.builder().userId(profileAuthResponseDto.getId()).build();
+    public static Profile toEntity(ProfileAuthRequest profileAuthRequest){
+        return Profile.builder().userId(profileAuthRequest.getId()).build();
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/UpdateProfileRequest.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/dto/profile/UpdateProfileRequest.java
@@ -1,12 +1,18 @@
 package pudding.toy.ourJourney.dto.profile;
 
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.util.Optional;
 
 @Data
 public class UpdateProfileRequest {
-    private Optional<String> nickname;
-    private Optional<String> imageUrl;
-    private Optional<String> selfIntroduction;
+    @Schema(description = "닉네임")
+    private JsonNullable<String> nickname;
+    @Schema(description = "프로필 이미지 URL")
+    private JsonNullable<String> imageUrl;
+    @Schema(description = "한줄 소개")
+    private JsonNullable<String> selfIntroduction;
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Profile.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Profile.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,7 +14,7 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class Profile {
+public class Profile extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
@@ -39,13 +41,17 @@ public class Profile {
     public String getProfileImg() {
         return profileImg;
     }
-
-    public Optional<String> getSelfIntroduction() {
-        return Optional.ofNullable(selfIntroduction);
+    public String getSelfIntroduction() {
+        return selfIntroduction;
     }
     @Builder
-    public Profile(Long userId, String nickName) {
+    public Profile(Long userId) {
         this.userId = userId;
-        this.nickName = nickName;
+        this.nickName = this.createRandomNickName();
+    }
+    public String createRandomNickName(){
+        final List<String> adjectives = Arrays.asList("예쁜", "졸린", "작은", "큰", "빠른", "따뜻한", "밝은", "산뜻한", "사랑스러운", "행복한", "귀여운");
+        int randomIndex = (int)(Math.random()*adjectives.size());
+        return adjectives.get(randomIndex)+"푸딩"+(int)(Math.random()*1000);
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/GenericMapper.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/GenericMapper.java
@@ -1,12 +1,8 @@
 package pudding.toy.ourJourney.mapper;
 
 import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
-import org.mapstruct.factory.Mappers;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
-import pudding.toy.ourJourney.entity.Contents;
 
 public interface GenericMapper<D,E> {
     D toDto(E e);

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/JsonNullableMapper.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/JsonNullableMapper.java
@@ -3,8 +3,6 @@ package pudding.toy.ourJourney.mapper;
 import org.mapstruct.Condition;
 import org.mapstruct.Mapper;
 import org.openapitools.jackson.nullable.JsonNullable;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
-import pudding.toy.ourJourney.entity.Contents;
 
 @Mapper(componentModel = "spring")
 public interface JsonNullableMapper {

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/UpdateContentsMapper.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/UpdateContentsMapper.java
@@ -1,13 +1,12 @@
 package pudding.toy.ourJourney.mapper;
 
 import org.mapstruct.*;
-import org.mapstruct.factory.Mappers;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
+import pudding.toy.ourJourney.dto.content.UpdateContentRequest;
 import pudding.toy.ourJourney.entity.Contents;
 
 @Mapper(uses = JsonNullableMapper.class,
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
         componentModel = "spring"
 )
-public interface EditContentsMapper extends GenericMapper<EditContentRequest,Contents>{
+public interface UpdateContentsMapper extends GenericMapper<UpdateContentRequest,Contents>{
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/UpdateProfileMapper.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/mapper/UpdateProfileMapper.java
@@ -1,0 +1,17 @@
+package pudding.toy.ourJourney.mapper;
+
+import io.swagger.v3.core.util.Json;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.openapitools.jackson.nullable.JsonNullable;
+import pudding.toy.ourJourney.dto.profile.UpdateProfileRequest;
+import pudding.toy.ourJourney.entity.Profile;
+
+import java.util.Optional;
+
+@Mapper(uses = JsonNullableMapper.class,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        componentModel =  "spring")
+public interface UpdateProfileMapper extends GenericMapper<UpdateProfileRequest,Profile> {
+}

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/AttendeeService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/AttendeeService.java
@@ -1,30 +1,18 @@
 package pudding.toy.ourJourney.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import pudding.toy.ourJourney.dto.content.CreateContentRequest;
-import pudding.toy.ourJourney.dto.content.DetailContentResponse;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
-import pudding.toy.ourJourney.dto.content.ListContentDto;
 import pudding.toy.ourJourney.entity.Attendee;
-import pudding.toy.ourJourney.entity.Category;
 import pudding.toy.ourJourney.entity.Contents;
 import pudding.toy.ourJourney.entity.Profile;
-import pudding.toy.ourJourney.mapper.EditContentsMapper;
 import pudding.toy.ourJourney.repository.AttendeeRepository;
-import pudding.toy.ourJourney.repository.CategoryRepository;
 import pudding.toy.ourJourney.repository.ContentRepository;
 import pudding.toy.ourJourney.repository.ProfileRepository;
 
-import java.awt.print.Pageable;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/AuthService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/AuthService.java
@@ -4,8 +4,6 @@ package pudding.toy.ourJourney.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
-import pudding.toy.ourJourney.entity.Profile;
 import pudding.toy.ourJourney.repository.ProfileRepository;
 
 @Service

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
@@ -11,7 +11,7 @@ import pudding.toy.ourJourney.dto.content.*;
 import pudding.toy.ourJourney.entity.Category;
 import pudding.toy.ourJourney.entity.Contents;
 import pudding.toy.ourJourney.entity.Profile;
-import pudding.toy.ourJourney.mapper.EditContentsMapper;
+import pudding.toy.ourJourney.mapper.UpdateContentsMapper;
 import pudding.toy.ourJourney.repository.CategoryRepository;
 import pudding.toy.ourJourney.repository.ContentRepository;
 import pudding.toy.ourJourney.repository.ContentsQueryRepository;
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class ContentService {
     private final ContentRepository contentRepository;
     private final CategoryRepository categoryRepository;
-    private final EditContentsMapper contentsMapper;
+    private final UpdateContentsMapper contentsMapper;
     private final AttendeeService attendeeService;
     private final TagService tagService;
     private final ContentsQueryRepository contentsQueryRepository;
@@ -68,7 +68,7 @@ public class ContentService {
         return DetailContentResponse.from(contents);
     }
 
-    public void updateContent(Long contentId, EditContentRequest editRequestDto) {
+    public void updateContent(Long contentId, UpdateContentRequest editRequestDto) {
         Contents contents = contentRepository.findById(contentId).orElseThrow(
                 ()-> new ResponseStatusException(HttpStatus.NOT_FOUND)
         );

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
@@ -5,9 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.server.ResponseStatusException;
-import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
+import pudding.toy.ourJourney.dto.auth.ProfileAuthRequest;
 import pudding.toy.ourJourney.dto.profile.GetDetailProfileResponse;
 import pudding.toy.ourJourney.dto.profile.NewProfileResponse;
 import pudding.toy.ourJourney.dto.profile.UpdateProfileRequest;
@@ -24,11 +23,11 @@ import java.util.*;
 public class ProfileService {
     private final ProfileRepository profileRepository;
     private final UpdateProfileMapper updateProfileMapper;
-    public NewProfileResponse createProfile(ProfileAuthResponseDto profileAuthResponseDto) {
-        profileRepository.findByUserId(profileAuthResponseDto.getId()).ifPresent(profile -> {
+    public NewProfileResponse createProfile(ProfileAuthRequest profileAuthRequest) {
+        profileRepository.findByUserId(profileAuthRequest.getId()).ifPresent(profile -> {
             throw new IllegalStateException("프로필이 존재합니다.");
         });
-        Profile profile = Profile.builder().userId(profileAuthResponseDto.getId()).build();
+        Profile profile = Profile.builder().userId(profileAuthRequest.getId()).build();
         profileRepository.save(profile);
         return new NewProfileResponse(profile.getId(),profile.getNickName());
     }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
@@ -2,36 +2,55 @@ package pudding.toy.ourJourney.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
 import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
+import pudding.toy.ourJourney.dto.profile.GetDetailProfileResponse;
 import pudding.toy.ourJourney.dto.profile.NewProfileResponse;
+import pudding.toy.ourJourney.dto.profile.UpdateProfileRequest;
 import pudding.toy.ourJourney.entity.Profile;
+import pudding.toy.ourJourney.mapper.UpdateProfileMapper;
 import pudding.toy.ourJourney.repository.ProfileRepository;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
+import java.time.LocalDateTime;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ProfileService {
     private final ProfileRepository profileRepository;
-    private final List<String> adjectives = Arrays.asList("예쁜", "졸린", "작은", "큰", "빠른", "따뜻한", "밝은", "산뜻한", "사랑스러운", "행복한", "귀여운");
-
+    private final UpdateProfileMapper updateProfileMapper;
     public NewProfileResponse createProfile(ProfileAuthResponseDto profileAuthResponseDto) {
         profileRepository.findByUserId(profileAuthResponseDto.getId()).ifPresent(profile -> {
             throw new IllegalStateException("프로필이 존재합니다.");
         });
-        Profile profile = Profile.builder().userId(profileAuthResponseDto.getId()).nickName(createRandomNickName()).build();
+        Profile profile = Profile.builder().userId(profileAuthResponseDto.getId()).build();
         profileRepository.save(profile);
         return new NewProfileResponse(profile.getId(),profile.getNickName());
     }
-    protected String createRandomNickName(){
-        int randomIndex = (int)(Math.random()*adjectives.size());
-        return adjectives.get(randomIndex)+"푸딩"+(int)(Math.random()*1000);
+    public GetDetailProfileResponse getDetailProfile(Long id){
+        Profile profile = profileRepository.findById(id).orElseThrow(
+                ()-> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        );
+        return new GetDetailProfileResponse(profile.getId(), profile.getNickName(), Optional.ofNullable(profile.getProfileImg()),Optional.ofNullable(profile.getSelfIntroduction()));
+    }
+    public void updateMyProfile(Long id, UpdateProfileRequest updateProfileRequest){
+        Profile profile = profileRepository.findById(id).orElseThrow(
+                ()-> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        );
+        updateProfileMapper.updateEntityFromDto(updateProfileRequest,profile);
+    }
+    public void deleteProfile(Long id){
+        //todo: login_required && is_owner?
+        Profile profile = profileRepository.findById(id).orElseThrow(
+                ()-> new ResponseStatusException(HttpStatus.NOT_FOUND)
+        );
+        profile.remove(LocalDateTime.now());
+        profileRepository.save(profile);
     }
 
 

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/TagService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/TagService.java
@@ -1,29 +1,17 @@
 package pudding.toy.ourJourney.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import pudding.toy.ourJourney.dto.content.CreateContentRequest;
-import pudding.toy.ourJourney.dto.content.DetailContentResponse;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
-import pudding.toy.ourJourney.dto.content.ListContentDto;
-import pudding.toy.ourJourney.entity.Category;
 import pudding.toy.ourJourney.entity.ContentTag;
 import pudding.toy.ourJourney.entity.Contents;
 import pudding.toy.ourJourney.entity.Tag;
-import pudding.toy.ourJourney.mapper.EditContentsMapper;
-import pudding.toy.ourJourney.repository.CategoryRepository;
-import pudding.toy.ourJourney.repository.ContentRepository;
 import pudding.toy.ourJourney.repository.ContentTagRepository;
 import pudding.toy.ourJourney.repository.TagRepository;
 
-import java.awt.print.Pageable;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/mapper/ContentMapperTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/mapper/ContentMapperTest.java
@@ -7,21 +7,15 @@ import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import pudding.toy.ourJourney.config.ProfileInitializer;
-import pudding.toy.ourJourney.dto.content.EditContentRequest;
+import pudding.toy.ourJourney.dto.content.UpdateContentRequest;
 import pudding.toy.ourJourney.entity.Category;
 import pudding.toy.ourJourney.entity.Contents;
-import pudding.toy.ourJourney.service.ContentService;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.FactoryBasedNavigableListAssert.assertThat;
 
 @Transactional
 @SpringBootTest
 public class ContentMapperTest {
     @Autowired
-    EditContentsMapper contentsMapper;
+    UpdateContentsMapper contentsMapper;
     Contents content;
     Category category;
     ProfileInitializer profileInitializer;
@@ -32,7 +26,7 @@ public class ContentMapperTest {
     }
     @Test
     void updateContentTest(){ //mapper 성공
-        EditContentRequest ed = EditContentRequest.builder()
+        UpdateContentRequest ed = UpdateContentRequest.builder()
                 .imgUrl(JsonNullable.of("img.png"))
                 .build();
         contentsMapper.updateEntityFromDto(ed,content);

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/service/AttendeeServiceTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/service/AttendeeServiceTest.java
@@ -27,7 +27,7 @@ public class AttendeeServiceTest {
 
     @BeforeEach
     public void setUp() {
-        profile = new Profile(3L,"hi");
+        profile = new Profile(3L);
         Category category = new Category("hhhh");
         categoryRepository.save(category);
         profileRepository.save(profile);

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/service/CommentServiceTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/service/CommentServiceTest.java
@@ -16,7 +16,6 @@ import pudding.toy.ourJourney.repository.ContentRepository;
 import pudding.toy.ourJourney.repository.ProfileRepository;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 
@@ -38,7 +37,7 @@ class CommentServiceTest {
     @Test
     void createCommentTest() {
         // given
-        Profile profile = profileRepository.save(new Profile(2L, "nickName"));
+        Profile profile = profileRepository.save(new Profile(2L));
         Contents contents = contentRepository.save(new Contents(profile, null, "title", null));
 
         // when
@@ -51,7 +50,7 @@ class CommentServiceTest {
     @Test
     void getCommentsTest() {
         // given
-        Profile profile = profileRepository.save(new Profile(2L, "nickName"));
+        Profile profile = profileRepository.save(new Profile(2L));
         Contents contents = contentRepository.save(new Contents(profile, null, "title", null));
 
         List<Comment> comments = IntStream.range(0, 11)
@@ -69,7 +68,7 @@ class CommentServiceTest {
     @Test
     void updateCommentTest() {
         // given
-        Profile profile = profileRepository.save(new Profile(2L, "nickName"));
+        Profile profile = profileRepository.save(new Profile(2L));
         Contents contents = contentRepository.save(new Contents(profile, null, "title", null));
         Comment comment = commentRepository.save(new Comment(profile, contents, "texts"));
 
@@ -85,7 +84,7 @@ class CommentServiceTest {
     @Test
     void deleteCommentTest() {
         // given
-        Profile profile = profileRepository.save(new Profile(2L, "nickName"));
+        Profile profile = profileRepository.save(new Profile(2L));
         Contents contents = contentRepository.save(new Contents(profile, null, "title", null));
         Comment comment = commentRepository.save(new Comment(profile, contents, "texts"));
 

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/service/NickNameRandomServiceTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/service/NickNameRandomServiceTest.java
@@ -3,11 +3,10 @@ package pudding.toy.ourJourney.service;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import pudding.toy.ourJourney.dto.auth.ProfileAuthResponseDto;
+import pudding.toy.ourJourney.dto.auth.ProfileAuthRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Random;
 
 @SpringBootTest
 public class NickNameRandomServiceTest {
@@ -23,8 +22,8 @@ public class NickNameRandomServiceTest {
     }
     @Test
     void createProfile(){
-        ProfileAuthResponseDto profileAuthResponseDto = new ProfileAuthResponseDto(3L);
-        System.out.println(profileService.createProfile(profileAuthResponseDto).getNickName());
+        ProfileAuthRequest profileAuthRequest = new ProfileAuthRequest(3L);
+        System.out.println(profileService.createProfile(profileAuthRequest).getNickName());
 
     }
 }


### PR DESCRIPTION
## 📝 제목
✨  feat: Profile 수정, 조회, 삭제 구현 + attendeeTest 문제 해결 + UpdateProfileMapper + Profile 자개소개 get 리턴값 변경
  
## ✨ 작업 내용
- Profile 수정, 조회, 삭제 구현했습니다. 이 과정에서 Profile이 BaseTimeEntity를 상속하게 되었습니다.
- Profile 생성자를 바꾸면서 생기는 attendeeTest 문제 해결했습니다.
- Patch를 위해  UpdateProfileMapper 를 생성했습니다 이 과정에서 JsonNullable을 사용하게 되어서  Profile 자개소개 get 리턴값 변경을 Optional -> JsonNullable이 되었습니다. 
  
## 💁‍♀️ 참고 사항
위에 다 적어두었습니다 ! 
  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->

  
## 🔧 앞으로의 과제
<!-- 작업 후, 남아있는 사항이나 기술 부채 등 작업한 내용과 연관되거나 해야할 사항이 있다면 남겨주세요. -->
<!-- 해당 내용들은 추후 새로운 태스크 등으로 등록하면서 관리하도록 해요. -->

  
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 [이슈 제목 #이슈번호](이슈 링크)로 남겨주세요. -->

  
