### PR TITLE
:bug: fix: create content 쿼리 두번 수정

### DIFF
--- a/ourJourney/src/main/java/pudding/toy/ourJourney/config/SecurityConfig.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package pudding.toy.ourJourney.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,8 +29,8 @@ public class SecurityConfig {
         return new JwtAuthenticationFilter(authService, userDetailService);
     }
 
-    public AuthExceptionFilter authExceptionFilter() {
-        return new AuthExceptionFilter();
+    public AuthExceptionFilter authExceptionFilter(ObjectMapper objectMapper) {
+        return new AuthExceptionFilter(objectMapper);
     }
 
     @Bean
@@ -45,7 +46,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, AuthService authService, CustomUserDetailService userDetailService) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthService authService, CustomUserDetailService userDetailService, ObjectMapper objectMapper) throws Exception {
         http
                 .cors(corsCustomizer -> corsCustomizer.configurationSource(configurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
@@ -59,7 +60,7 @@ public class SecurityConfig {
         http
                 .addFilterBefore(jwtAuthenticationFilter(authService, userDetailService), UsernamePasswordAuthenticationFilter.class);
         http
-                .addFilterBefore(authExceptionFilter(), JwtAuthenticationFilter.class);
+                .addFilterBefore(authExceptionFilter(objectMapper), JwtAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/config/error/ErrorResponse.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/config/error/ErrorResponse.java
@@ -1,0 +1,21 @@
+package pudding.toy.ourJourney.config.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    int status;
+    String message;
+
+    public static ErrorResponse error(HttpStatus status, String message) {
+        return new ErrorResponse(status.value(), message);
+    }
+
+    public static ErrorResponse error(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+}

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Contents.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Contents.java
@@ -1,7 +1,10 @@
 package pudding.toy.ourJourney.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.hibernate.annotations.Where;
 
@@ -33,6 +36,8 @@ public class Contents extends BaseTimeEntity {
     List<ContentLike> contentLikes;
     @OneToMany(mappedBy = "contents")
     List<ContentsThread> contentsThreads;
+    @OneToMany(mappedBy = "contents")
+    List<Attendee> attendees;
 
     public Contents(Profile profile, Category category, String title, String imgUrl) {
         this.title = title;
@@ -42,10 +47,10 @@ public class Contents extends BaseTimeEntity {
     }
 
     @Builder
-    public Contents(String title, Category category, ContentTag contentTag,Profile profile) {
+    public Contents(String title, Category category, ContentTag contentTag, Profile profile) {
         this.title = title;
         this.category = category;
-        this.contentTags  = new ArrayList<>();
+        this.contentTags = new ArrayList<>();
         this.contentLikes = new ArrayList<>();
         this.profile = profile;
         this.contentsThreads = new ArrayList<>();
@@ -69,6 +74,18 @@ public class Contents extends BaseTimeEntity {
     public void addTags(List<ContentTag> contentTags) {
         for (ContentTag tags : contentTags) {
             this.addTag(tags);
+        }
+    }
+
+    public void addAttendee(Attendee attendee) {
+        if (attendee != null) {
+            this.attendees.add(attendee);
+        }
+    }
+
+    public void addAttendees(List<Attendee> attendees) {
+        for (Attendee attendee : attendees) {
+            this.addAttendee(attendee);
         }
     }
 

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Follow.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/entity/Follow.java
@@ -15,17 +15,22 @@ public class Follow {
     @ManyToOne
     @JoinColumn(name = "follower_user_id")
     Profile follower;
+
     @ManyToOne
     @JoinColumn(name = "following_user_id")
     Profile following;
+
     public Follow(Profile follower, Profile following) {
         this.follower = follower;
         this.following = following;
     }
+
     public Profile getFollower() {
         return this.follower;
     }
+
     public Profile getFollowing() {
         return this.following;
     }
+
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
@@ -20,13 +20,17 @@ public class AuthExceptionFilter extends OncePerRequestFilter {
         try {
             chain.doFilter(request, response);
             return;
-        } catch (ResponseStatusException ex) {
+        } catch (Exception ex) {
             // 인증 관련 예외만 필터에서 처리
-            response.setStatus(ex.getStatusCode().value());
-            String reason = ex.getReason() != null ? ex.getReason() : "Error occurred";
-            response.getWriter().write(reason);
-        } catch (Exception e) {
-            throw e;
+            if (ex instanceof ResponseStatusException e) {
+                response.setStatus(e.getStatusCode().value());
+                String reason = e.getReason() != null ? e.getReason() : "Authentication failed";
+                response.getWriter().write(reason);
+                response.setCharacterEncoding("UTF-8"); // 응답 인코딩 설정
+                response.setContentType("application/json; charset=UTF-8"); // 응답 타입 설정
+                return;
+            }
+            throw ex;
         }
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
@@ -6,10 +6,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.io.IOException;
 
 
@@ -18,12 +17,16 @@ import java.io.IOException;
 public class AuthExceptionFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        try{
-            chain.doFilter(request,response);
+        try {
+            chain.doFilter(request, response);
             return;
-        }catch (Exception e){
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } catch (ResponseStatusException ex) {
+            // 인증 관련 예외만 필터에서 처리
+            response.setStatus(ex.getStatusCode().value());
+            String reason = ex.getReason() != null ? ex.getReason() : "Error occurred";
+            response.getWriter().write(reason);
+        } catch (Exception e) {
+            throw e;
         }
-
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/filter/AuthExceptionFilter.java
@@ -1,5 +1,6 @@
 package pudding.toy.ourJourney.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.server.ResponseStatusException;
+import pudding.toy.ourJourney.config.error.ErrorResponse;
 
 import java.io.IOException;
 
@@ -15,6 +17,8 @@ import java.io.IOException;
 @Slf4j
 @RequiredArgsConstructor
 public class AuthExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         try {
@@ -25,9 +29,10 @@ public class AuthExceptionFilter extends OncePerRequestFilter {
             if (ex instanceof ResponseStatusException e) {
                 response.setStatus(e.getStatusCode().value());
                 String reason = e.getReason() != null ? e.getReason() : "Authentication failed";
-                response.getWriter().write(reason);
-                response.setCharacterEncoding("UTF-8"); // 응답 인코딩 설정
-                response.setContentType("application/json; charset=UTF-8"); // 응답 타입 설정
+                response.setContentType("application/json; charset=UTF-8");
+                response.setCharacterEncoding("UTF-8");
+                String json = objectMapper.writeValueAsString(ErrorResponse.error(response.getStatus(), reason));
+                response.getWriter().write(json);
                 return;
             }
             throw ex;

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/filter/JwtAuthenticationFilter.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/filter/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CustomUserDetailService userDetailService;
     private static final String[] exceptURIs = {
             "/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**",
-            "/contents/*", "/categories", "/contents", "/tags", "/health"
+            "/contents/*", "/categories", "/contents", "/tags", "/health", "/tags"
     };
     private static final String regex = "^/profiles/\\d+$";
 

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package pudding.toy.ourJourney.handler;
 
 
-import lombok.Data;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.http.HttpStatus;
@@ -11,51 +10,31 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import pudding.toy.ourJourney.config.error.ErrorResponse;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // ResponseStatusException 처리
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
-        ErrorResponse error = new ErrorResponse(ex.getStatusCode().value(), ex.getMessage());
-        return new ResponseEntity<>(error, ex.getStatusCode());
+        return new ResponseEntity<>(ErrorResponse.error(ex.getStatusCode().value(), ex.getReason()), ex.getStatusCode());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
-        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(ErrorResponse.error(HttpStatus.BAD_REQUEST, e.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ChangeSetPersister.NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(ChangeSetPersister.NotFoundException e) {
-        ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND, e.getMessage());
-        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(ErrorResponse.error(HttpStatus.NOT_FOUND, e.getMessage()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(DuplicateKeyException.class)
     protected ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException e) {
-        ErrorResponse error = new ErrorResponse(HttpStatus.CONFLICT, e.getMessage());
-        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+        return new ResponseEntity<>(ErrorResponse.error(HttpStatus.CONFLICT, e.getMessage()), HttpStatus.CONFLICT);
     }
-
-    @Data
-    private static class ErrorResponse {
-        int status;
-        String message;
-
-        ErrorResponse(HttpStatus status, String message) {
-            this.status = status.value();
-            this.message = message;
-        }
-
-        ErrorResponse(int status, String message) {
-            this.status = status;
-            this.message = message;
-        }
-    }
-
 
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package pudding.toy.ourJourney.handler;
+
+
+import lombok.Data;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    // ResponseStatusException 처리
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
+        ErrorResponse error = new ErrorResponse(ex.getStatusCode().value(), ex.getMessage());
+        return new ResponseEntity<>(error, ex.getStatusCode());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ChangeSetPersister.NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(ChangeSetPersister.NotFoundException e) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    protected ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException e) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.CONFLICT, e.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+
+    @Data
+    private static class ErrorResponse {
+        int status;
+        String message;
+
+        ErrorResponse(HttpStatus status, String message) {
+            this.status = status.value();
+            this.message = message;
+        }
+
+        ErrorResponse(int status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+    }
+
+
+}

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/handler/GlobalExceptionHandler.java
@@ -41,13 +41,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-
     @Data
     private static class ErrorResponse {
         int status;

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/AuthService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
             String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 부분을 추출
             return getAuth(accessToken);
         }
-        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "맞지 않은 토큰입니다.");
     }
 
     public AuthResponse getAuth(String accessToken) {
@@ -41,7 +41,7 @@ public class AuthService {
         HttpEntity<Object> entity = new HttpEntity<>(headers);
         ResponseEntity<AuthResponse> response = authRestTemplate.exchange("/auth/certificate", HttpMethod.GET, entity, AuthResponse.class);
         if (response.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
         }
         return response.getBody();
     }
@@ -65,6 +65,6 @@ public class AuthService {
     }
 
     public Profile getProfileWithAuthorize() {
-        return currentProfile().orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        return currentProfile().orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."));
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
@@ -82,7 +82,7 @@ public class ContentService {
     private void addContentTag(List<Long> tagIds, Contents content) {
         List<Tag> tags = tagRepository.findAllById(tagIds);
         if (tagIds.size() != tags.size()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "태그가 생성되지 않았어요.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 태그가 없습니다.");
         }
         List<ContentTag> contentTags = tags.stream()
                 .map(tag -> new ContentTag(content, tag))
@@ -92,7 +92,7 @@ public class ContentService {
 
     public DetailContentResponse getDetailContent(Long contentId, Optional<Profile> profile) {
         Contents contents = contentRepository.findById(contentId).orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 글이 없습니다.")
         );
         Long likeCount = contentLikeRepository.countByContentsId(contentId);
         Long totalCount = commentRepository.countByContentsIdAndDeletedAtIsNull(contentId);

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ContentService.java
@@ -52,7 +52,7 @@ public class ContentService {
                 .category(category)
                 .build();
         contentRepository.save(content);
-        
+
         createContentRequest.getImgUrl().ifPresent(content::setImgUrl);
         createContentRequest.getAttendeeIds()
                 .filter(profileIds -> !profileIds.isEmpty())
@@ -77,7 +77,6 @@ public class ContentService {
                 .map(profile -> new Attendee(profile, content))
                 .toList();
         attendeeRepository.saveAll(attendees);
-        content.addAttendees(attendees);
     }
 
     private void addContentTag(List<Long> tagIds, Contents content) {
@@ -89,7 +88,6 @@ public class ContentService {
                 .map(tag -> new ContentTag(content, tag))
                 .toList();
         contentTagRepository.saveAll(contentTags);
-        content.addTags(contentTags);
     }
 
     public DetailContentResponse getDetailContent(Long contentId, Optional<Profile> profile) {

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/CustomUserDetailService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/CustomUserDetailService.java
@@ -17,13 +17,15 @@ import pudding.toy.ourJourney.repository.ProfileRepository;
 @Transactional
 public class CustomUserDetailService implements UserDetailsService {
     private final ProfileRepository profileRepository;
+
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        Profile profile =  profileRepository.findByUserId(Long.parseLong(userId)).orElseThrow(()-> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        Profile profile = profileRepository.findByUserId(Long.parseLong(userId)).orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 사용자입니다."));
         return new CustomUserDetail(profile);
     }
-    public UserDetails loadUserByUserId(Long id) throws UsernameNotFoundException{
-        Profile profile =  profileRepository.findByUserId(id).orElseThrow(()-> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+
+    public UserDetails loadUserByUserId(Long id) throws UsernameNotFoundException {
+        Profile profile = profileRepository.findByUserId(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 사용자입니다."));
         return new CustomUserDetail(profile);
     }
 }

--- a/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
+++ b/ourJourney/src/main/java/pudding/toy/ourJourney/service/ProfileService.java
@@ -83,7 +83,6 @@ public class ProfileService {
     }
 
     public void deleteProfile(Long id) {
-        //todo: login_required && is_owner?
         Profile profile = profileRepository.findById(id).orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND)
         );

--- a/ourJourney/src/test/java/pudding/toy/ourJourney/service/AuthServiceTest.java
+++ b/ourJourney/src/test/java/pudding/toy/ourJourney/service/AuthServiceTest.java
@@ -1,11 +1,15 @@
 package pudding.toy.ourJourney.service;
+
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import pudding.toy.ourJourney.dto.auth.AuthResponse;
-import static org.junit.jupiter.api.Assertions.*;
+
+import javax.naming.AuthenticationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @Transactional
@@ -16,7 +20,7 @@ class AuthServiceTest {
 
     @Disabled
     @Test
-    void getAuthTest() {
+    void getAuthTest() throws AuthenticationException {
         AuthResponse response = authService.getAuth("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzI2ODQ0ODkwLCJpYXQiOjE3MjY4NDMwOTAsImp0aSI6IjhlMmEyNzdhZjE5ZDQ2NGZiOTcyNDJmOTExNDZhYTE5IiwidXNlcl9pZCI6MjJ9.FGLXGsrFzdGEj2IvjwaIxoJRF7LB3rtj-57w3pJexHc");
         assertEquals(response.getUserId(), 22);
     }


### PR DESCRIPTION
## 📝 제목
:bug: fix: create content 쿼리 두번 수정 및 에러 핸들러 메세지 추가.
  
  
## ✨ 작업 내용
- create Content 가능(참석자와 태그 모두 가능) -> 쿼리 두번 나가는 거 수정했습니다. 
- 에러 핸들러랑, 에러 커스텀 추가했습니다. 
- 필터 단의 jwt 에러와 서비스 단이 처리해야할 에러를 분리하기 위해 필요했습니다.
- 토큰 만료 시, 500 에러 리턴하는 것 수정 -> 401 에러 리턴 
  
  
## 💁‍♀️ 참고 사항
- RestTemplate으로 발생한 에러는 ``HttpClientErrorException$Unauthorized ``에러를 리턴함. -> response status 401로 구별하려고 했기에, 다른 필터로 계속 에러가 넘어가서 500에러를 리턴한거였음. 
- response.getWriter().write() 전에 ObjectMapper로 감싸야지만 json으로 변환할 수 있음. 필터에서는 RestController 넘어가기 전이기 때문에 사용자가 ObjectMapper로 변환시켜 줘야 함. 
  
## 🤔 논의 사항
<!-- 작업하는 데에 있어서 고민되었던 내용이 있으셨나요? -->
<!-- 여기에 내용을 남겨주시면, 팀원들이 내용을 읽고 함께 논의해드릴 거예요. -->

  
## 🔧 앞으로의 과제
<!-- 작업 후, 남아있는 사항이나 기술 부채 등 작업한 내용과 연관되거나 해야할 사항이 있다면 남겨주세요. -->
<!-- 해당 내용들은 추후 새로운 태스크 등으로 등록하면서 관리하도록 해요. -->

  
## 🚨 관련 이슈
<!-- 작업과 관련하여 남아있는 이슈 등이 있다면 여기에 작성해주세요. -->
<!-- 작성하실 때는 [이슈 제목 #이슈번호](이슈 링크)로 남겨주세요. -->

  
